### PR TITLE
Improved Copy/Paste Behavior for Sections of Web Pages, Various Regex Improvements

### DIFF
--- a/app/util.js
+++ b/app/util.js
@@ -77,7 +77,7 @@
 
     const code_block = /```([\s\S]*?)```/gm;
     const a = /((https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)))(">(.*)<\/a>)?/ig;
-    const pre_link = /(<a href="http).+(<\/a>)/ig; //check if input text is already a valid link
+    const already_html_link = /(<a href="http).+(<\/a>)/ig;
     const styles = {
         samp: /`(\S.*?\S|\S)`/g,
         mark: /==(\S.*?\S|\S)==/g,
@@ -125,14 +125,16 @@
         /* Do all the inline ones now */
         const buf = [];
         for (const segment of stack) {
+            console.log('segment: ', segment);
             if (segment.protected) {
                 buf.push(segment.value);
-            } else {
+            } 
+            else {
                 let val = segment.value;
                 for (const tag in styles) {
-                    val = val.replace(styles[tag], `<${tag}>$1</${tag}>`);    
+                    val = val.replace(styles[tag], `<${tag}>$1</${tag}>`);  
                 }
-                if(!val.match(pre_link)) { //if input text is a valid link, do not affix new <a> tags.
+                if(!val.match(already_html_link)) {
                     let url_val = val.match(a);
                     val = val.replace(a, `<a href=${url_val}>${url_val}</a>`);
                 }

--- a/app/views/compose.js
+++ b/app/views/compose.js
@@ -10,7 +10,7 @@
     const TAB_KEY = 9;
     const UP_KEY = 38;
     const DOWN_KEY = 40;
-    var dirty_flag = 0;
+    let dirty_flag = 0;
 
     F.ComposeView = F.View.extend({
         template: 'article/compose.html',
@@ -60,8 +60,8 @@
             const el = this.$messageField[0];
             const raw = el.innerHTML;
             const plain = F.emoji.colons_to_unicode(el.innerText.trim());
-            console.info(F.emoji.colons_to_unicode(raw));
             var html;
+            console.info('flag status: ', dirty_flag);
             if(dirty_flag) {
                 html = raw; //if DOMpurify results in output differing from input, do not call fostadownConvert()
             }


### PR DESCRIPTION
### Description

- Modified regex behavior for highlight (\<mark\> tag) - now requires double equals sign '=='
- Added var flag to determine if htmlSanitize results in output differing from input (i.e. whether input is 'clean'): if it is clean, the flag allows us to call forstadownConvert to change markup tags to html in the send function, otherwise it prevents forstadownConvert from doing so (this prevents a lot of the bungled garbage that was being produced when we pasted in sections of webpages)
- Added additional regex for <a> tags, which are not caught by htmlSanitize, preventing links from being broken by forstadownConvert, as they had previously


