### PR TITLE
File Attachments Display Paperclip Thumbnail and Associated CSS Changes

### DIFF
--- a/app/models/messages.js
+++ b/app/models/messages.js
@@ -101,7 +101,8 @@
                 const a = att[0];
                 if (a.name && a.name.length) {
                     fields.push(a.name);
-                } else if (a.type && a.type.length) {
+                }
+                if (a.type && a.type.length) {
                     const parts = att[0].type.toLowerCase().split('/');
                     const type =  (parts[0] === 'application') ? parts[1] : parts[0];
                     fields.push(type[0].toUpperCase() + type.slice(1) + ' Attachment');

--- a/app/views/message.js
+++ b/app/views/message.js
@@ -253,12 +253,22 @@
                 const clean = F.util.htmlSanitize(model_attrs.html);
                 html_safe = F.emoji.replace_unified(clean);
             }
+            let viewType = 0;
+            if (this.model.attributes.attachments.length) {
+                let t = this.model.attributes.attachments[0].type.split("/")[0];
+                if (t !== "image" && t !== "video" && t !== "audio") {
+                    viewType = 1;
+                }
+            }
+
             return Object.assign({
                 sender: this._sender.getName(),
                 avatar: this._sender.getAvatar(),
                 incoming: this.model.isIncoming(),
                 meta: this.model.getMeta(),
-                html_safe
+                html_safe,
+                viewType,
+                thumbnail: F.urls.static + "images/paperclip.svg"
             }, model_attrs);
         },
 

--- a/stylesheets/main.scss
+++ b/stylesheets/main.scss
@@ -409,6 +409,18 @@ nav > .ui.segment {
         }
     }
 
+    .ui.feed .extra.images.attachments {
+        img.textAttachment {
+            padding-right: 5px;
+            height: 2.5em;
+            width: auto;
+        }
+
+        a {
+            font-size: 1.5em;
+        }
+
+    }
 
     .ui.feed .extra.attachments .attachment {
         img, audio, video {

--- a/templates/article/messages-item.html
+++ b/templates/article/messages-item.html
@@ -31,7 +31,11 @@
                     <div class="extra text">{{plain}}</div>
                 {{/if}}
                 {{#if attachments.length}}
-                    <div class="extra images attachments"></div>
+                    <div class="extra images attachments">
+                        {{#if viewType}}
+                            <img class="textAttachment" src="{{thumbnail}}"/>
+                        {{/if}}    
+                    </div>
                 {{/if}}
                 {{#if meta.length}}
                     <div class="meta">


### PR DESCRIPTION
### Description
* attachments which are not images, video, or audio now display with a paperclip thumbnail
* changes to associated CSS to make text file attachments all pretty like
