### PR TITLE
Fixed Runaway Oembed Issue on Webpage Section Copy/Paste

### DIFF
--- a/app/views/message.js
+++ b/app/views/message.js
@@ -233,7 +233,7 @@
         },
 
         renderEmbed: function() {
-            this.$('.extra.text a').oembed();
+            this.$('.extra.text a[type="unfurlable"]').oembed();
         },
 
         renderExpiring: function() {

--- a/lib/forstadown.js
+++ b/lib/forstadown.js
@@ -18,7 +18,7 @@
         tag: 'a',
         stop_on_match: true,
         match: /((https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)))(">(.*)<\/a>)?/ig,
-        sub: '<a href="$1">$1</a>',
+        sub: '<a href="$1" type="unfurlable">$1</a>',
         parent_blacklist: ['a']
     }, {
         tag: 'samp',

--- a/tests/data.json
+++ b/tests/data.json
@@ -77,7 +77,7 @@
   }, {
     "name": "Link test",
     "input": "https://github.com/ms2300",
-    "expected": "<a href=\"https://github.com/ms2300\">https://github.com/ms2300</a>"
+    "expected": "<a href=\"https://github.com/ms2300\" type=\"unfurlable\">https://github.com/ms2300</a>"
   }, {
     "name": "Link test 2",
     "input": "github.com/ms2300",
@@ -85,7 +85,7 @@
   }, {
     "name": "Link test 3",
     "input": "https://stackoverflow.com/questions/14415881/how-to-pair-socks-from-a-pile-efficiently",
-    "expected": "<a href=\"https://stackoverflow.com/questions/14415881/how-to-pair-socks-from-a-pile-efficiently\">https://stackoverflow.com/questions/14415881/how-to-pair-socks-from-a-pile-efficiently</a>"
+    "expected": "<a href=\"https://stackoverflow.com/questions/14415881/how-to-pair-socks-from-a-pile-efficiently\" type=\"unfurlable\">https://stackoverflow.com/questions/14415881/how-to-pair-socks-from-a-pile-efficiently</a>"
   }, {
     "name": "Simple Code test",
     "input": "```SuperGNerd```",


### PR DESCRIPTION
#### Description
* previously, oembed would run on any links present within message divs, sometimes resulting in cascading embedded content (wikipedia copy/pastes were particularly prone to this)
    - this caused lag on message render and would create a ridiculously long message
* commit adds "unfurlable" type to linkified text which has been made into a link by fdconvert (this is the main use case for oembed)
* prevents oembed from running on link tags from pasted webpage content