### PR TITLE
Fixes #160, shows clean messages for deleted users

### DIFF
--- a/app/atlas.js
+++ b/app/atlas.js
@@ -196,4 +196,10 @@
             }
         }
     };
+
+    ns.isUniversalTag = async function(tag) {
+        let uuidRegex = "/^<[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/>$/";
+        return tag.match(uuidRegex);
+    };
+
 })();

--- a/app/models/threads.js
+++ b/app/models/threads.js
@@ -12,14 +12,14 @@
             return;
         } 
         var detailMsg = [];
-        var usersRemoved = 0;
+        const usersRemoved = 0;
         for (const warning in warnings) {
             const isTag = F.atlas.isUniversalTag(escape(warning.cue));
             if (isTag) {
                 usersRemoved++;
             }
         }
-        if (usersRemoved == 1) {
+        if (usersRemoved === 1) {
             detailMsg.push(`Removed deleted user`);
         } else if (usersRemoved > 1) {
             detailMsg.push(`Removed ${usersRemoved} deleted users`);

--- a/app/models/threads.js
+++ b/app/models/threads.js
@@ -11,7 +11,7 @@
         if (!warnings.length) {
             return;
         } 
-        const detailMsg = [];
+        let detailMsg = [];
         var usersRemoved = 0;
         for (const warning in warnings) {
             const isTag = F.atlas.isUniversalTag(escape(warning.cue));

--- a/app/models/threads.js
+++ b/app/models/threads.js
@@ -11,8 +11,8 @@
         if (!warnings.length) {
             return;
         } 
-        var detailMsg = [];
-        const usersRemoved = 0;
+        const detailMsg = [];
+        var usersRemoved = 0;
         for (const warning in warnings) {
             const isTag = F.atlas.isUniversalTag(escape(warning.cue));
             if (isTag) {


### PR DESCRIPTION
When a user was deleted, the thread would update and show the userid tags of who was deleted or show nothing. The repaired distribution message was also a mess with the userids and the pretty version. 

Also the old and new distributions of the "Repaired distribution" message were off. It would include a bunch of extra + as well as the old wouldn't have your tag while the new one does have your tag. So now they match correctly and show the correct old/new distribution(excluding yourself).

Old:
![old](https://user-images.githubusercontent.com/19195026/34011398-1ed9d252-e0cd-11e7-86d0-b0eb2fe694d0.png)
 
New:
![screen shot 2017-12-14 at 12 37 02 pm](https://user-images.githubusercontent.com/19195026/34011414-28082e46-e0cd-11e7-9ce8-67ed246a1db8.png)
![screen shot 2017-12-14 at 12 37 58 pm](https://user-images.githubusercontent.com/19195026/34011415-28208720-e0cd-11e7-9f46-fc721295e474.png)

