### PR TITLE
Added appBundleId

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,7 @@ electron:
 		--overwrite \
 		--icon images/$$([ "$(shell uname)" == "Darwin" ] && echo app.icns || echo app.png) \
 		--out builds \
+		--appBundleId io.forsta.messenger \
 		$(ELECTRON_IGNORES)
 
 electron-win32:
@@ -147,6 +148,7 @@ electron-darwin:
 		--platform darwin \
 		--icon images/app.icns \
 		--out builds \
+		--appBundleId io.forsta.messenger \
 		$(ELECTRON_IGNORES)
 
 electron-linux:

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "morgan": "1.9.0"
   },
   "devDependencies": {
-    "electron": "2.0.0-beta.2",
+    "electron": "2.0.0-beta.3",
     "electron-packager": "11.1.0",
     "eslint": "4.17.0",
     "grunt-contrib-watch": "1.0.0",


### PR DESCRIPTION
* Added appBundleId - fixes incorrect app icon in macOS notifications
* Bumped to electron 2.0.0-b3