### PR TITLE
#266, #265, org banner and custom css

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -89,6 +89,10 @@
 
     async function initTheme() {
         F.util.chooseTheme(await F.state.get('theme', 'default'));
+        const orgStylesheet = (await F.currentUser.getOrg()).get('custom_css');
+        if (orgStylesheet) {
+            $('<style type="text/css">').text(orgStylesheet).appendTo('head');
+        }
     }
 
     const preloaded = (async () => {

--- a/stylesheets/_header.scss
+++ b/stylesheets/_header.scss
@@ -20,6 +20,11 @@
                 height: 1.56em;
                 width: initial;
             }
+        } 
+
+        div.f-org-name {
+            position:absolute;
+            top: 43px;
         }
 
         .f-toc {

--- a/templates/views/header.html
+++ b/templates/views/header.html
@@ -8,7 +8,14 @@
             </i>
         </div>
         <div class="f-brand item fitted">
-            <img class="f-logo" alt="Forsta" src="{{static 'images/logo_just_text.svg'}}"/>
+            <img class="f-logo" alt="Forsta" 
+                {{#if orgAttrs.banner}} 
+                    src="{{orgAttrs.banner}}"
+                {{else}}
+                    src="{{static 'images/logo_just_text.svg'}}"
+                {{/if}}
+                />
+            <div class="f-org-name">{{orgAttrs.slug}}</div>
         </div>
     </div>
 


### PR DESCRIPTION
> put the condition around the src attribute itself so we don't have to grok that the only difference is that one attribute

Wasn't able to do this one. Putting the conditional around the attribute alone breaks the template. I wasn't able to find any examples on handlebarjs.com.