### PR TITLE
Fix unregistered detection regression found by Ben.

### DIFF
--- a/app/foundation.js
+++ b/app/foundation.js
@@ -579,7 +579,15 @@
 
         async _refresh() {
             const start = Date.now();
-            const timestamp = await this.signal.getTimestamp();
+            let timestamp;
+            try {
+                timestamp = await this.signal.getTimestamp();
+            } catch(e) {
+                if (e.code === 401) {
+                    await F.util.resetRegistration();  // reloads page
+                }
+                throw e;
+            }
             const now = Date.now();
             const latency = now - start;
             this.lastRefresh = now;


### PR DESCRIPTION
Perform the same 401 (unauthorized) check during timestamp service
refresh that we do in other places to determine our reg state.  Reset
reg as needed.