### PR TITLE
Adding Call Type Button Options

### DIFF
--- a/app/calling.js
+++ b/app/calling.js
@@ -71,6 +71,15 @@
             if (options.autoJoin) {
                 await this.view.join();
             }
+            if (options.remAudioButton) {
+                await this.view.remAudioButton();
+            }
+            if (options.remVideoButton) {
+                await this.view.remVideoButton();
+            }
+            if (options.remScreenshareButton) {
+                await this.view.remScreenshareButton();
+            }
         }
 
         async _startIncoming(data, type, options) {

--- a/app/views/call.js
+++ b/app/views/call.js
@@ -487,6 +487,19 @@
             }
             return F.View.prototype.remove.call(this);
         },
+                                     
+        remAudioButton: async function() {
+            this.$('[data-type="audio"]').remove();
+            this.$('.or').first().remove();
+        },
+        remVideoButton: async function() {
+            this.$('[data-type="video"]').remove();
+            this.$('.or').last().remove();
+        },
+        remScreenshareButton: async function() {
+            this.$('[data-type="screenshare"]').remove();
+            this.$('.or').last().remove();
+        },
 
         _cleanup: function() {
             for (const track of this.outStream.getTracks()) {


### PR DESCRIPTION
Added the ability to remove any number of the three call types (audio, video, screenshare) from the callView. Options are passed through threadCallStart.